### PR TITLE
Add wildcard handling of abs traversal

### DIFF
--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -185,10 +185,14 @@ func (e *RelativeTraversalExpr) StartRange() hcl.Range {
 
 // Implementation for hcl.AbsTraversalForExpr.
 func (e *RelativeTraversalExpr) AsTraversal() hcl.Traversal {
+	var st hcl.Traversal
+	var diags hcl.Diagnostics
 	// We can produce a traversal only if our source can.
-	st, diags := hcl.AbsTraversalForExpr(e.Source)
-	if diags.HasErrors() {
-		return nil
+	if _, ok := e.Source.(*AnonSymbolExpr); !ok {
+		st, diags = hcl.AbsTraversalForExpr(e.Source)
+		if diags.HasErrors() {
+			return nil
+		}
 	}
 
 	ret := make(hcl.Traversal, len(st)+len(e.Traversal))
@@ -1354,10 +1358,14 @@ func (e *ObjectConsKeyExpr) AsTraversal() hcl.Traversal {
 		return nil
 	}
 
+	var st hcl.Traversal
+	var diags hcl.Diagnostics
 	// We can produce a traversal only if our wrappee can.
-	st, diags := hcl.AbsTraversalForExpr(e.Wrapped)
-	if diags.HasErrors() {
-		return nil
+	if _, ok := e.Wrapped.(*AnonSymbolExpr); !ok {
+		st, diags = hcl.AbsTraversalForExpr(e.Wrapped)
+		if diags.HasErrors() {
+			return nil
+		}
 	}
 
 	return st
@@ -1962,13 +1970,20 @@ func (e *SplatExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 }
 
 func (e *SplatExpr) AsTraversal() hcl.Traversal {
-	st, diags := hcl.AbsTraversalForExpr(e.Source)
-	if diags.HasErrors() {
-		return nil
+	var et, st hcl.Traversal
+	var diags hcl.Diagnostics
+	// We need to double-check that there's anything after this expression, or if it's just empty
+	if _, ok := e.Source.(*AnonSymbolExpr); !ok {
+		st, diags = hcl.AbsTraversalForExpr(e.Source)
+		if diags.HasErrors() {
+			return nil
+		}
 	}
-	et, diags := hcl.AbsTraversalForExpr(e.Each)
-	if diags.HasErrors() {
-		return nil
+	if _, ok := e.Each.(*AnonSymbolExpr); !ok {
+		et, diags = hcl.AbsTraversalForExpr(e.Each)
+		if diags.HasErrors() {
+			return nil
+		}
 	}
 	traversal := make(hcl.Traversal, len(st)+1+len(et))
 	copy(traversal, st)

--- a/hclsyntax/expression.go
+++ b/hclsyntax/expression.go
@@ -1961,6 +1961,22 @@ func (e *SplatExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	}
 }
 
+func (e *SplatExpr) AsTraversal() hcl.Traversal {
+	st, diags := hcl.AbsTraversalForExpr(e.Source)
+	if diags.HasErrors() {
+		return nil
+	}
+	et, diags := hcl.AbsTraversalForExpr(e.Each)
+	if diags.HasErrors() {
+		return nil
+	}
+	traversal := make(hcl.Traversal, len(st)+1+len(et))
+	copy(traversal, st)
+	copy(traversal[len(st):], []hcl.Traverser{hcl.TraverseSplat{}})
+	copy(traversal[len(st)+1:], et)
+	return traversal
+}
+
 func (e *SplatExpr) walkChildNodes(w internalWalkFunc) {
 	w(e.Source)
 	w(e.Each)

--- a/hclsyntax/expression_test.go
+++ b/hclsyntax/expression_test.go
@@ -2917,6 +2917,85 @@ func TestExpressionAsTraversal(t *testing.T) {
 	}
 }
 
+func TestSplatExpressionXAsTraversal(t *testing.T) {
+	expr, _ := ParseExpression([]byte("module.team[\"team_b\"].module.player[\"c\"].random_pet.ball[*]"), "", hcl.Pos{})
+	traversal, diags := hcl.AbsTraversalForExpr(expr)
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics:\n%s", diags.Error())
+	}
+	if len(traversal) != 9 {
+		t.Fatalf("wrong traversal %#v; want length 9", traversal)
+	}
+	if traversal.RootName() != "module" {
+		t.Errorf("wrong root name %q; want %q", traversal.RootName(), "a")
+	}
+	if step, ok := traversal[1].(hcl.TraverseAttr); ok {
+		if got, want := step.Name, "team"; got != want {
+			t.Errorf("wrong name %q for step 1; want %q", got, want)
+		}
+	} else {
+		t.Errorf("wrong type %T for step 1; want %T", traversal[1], step)
+	}
+	if step, ok := traversal[2].(hcl.TraverseIndex); ok {
+		if got, want := step.Key, cty.StringVal("team_b"); !want.RawEquals(got) {
+			t.Errorf("wrong name %#v for step 2; want %#v", got, want)
+		}
+	} else {
+		t.Errorf("wrong type %T for step 2; want %T", traversal[2], step)
+	}
+	if step, ok := traversal[3].(hcl.TraverseAttr); ok {
+		if got, want := step.Name, "module"; got != want {
+			t.Errorf("wrong name %q for step 3; want %q", got, want)
+		}
+	} else {
+		t.Errorf("wrong type %T for step 3; want %T", traversal[3], step)
+	}
+	if step, ok := traversal[8].(hcl.TraverseSplat); !ok {
+		t.Errorf("wrong type %T for step 8; want %T", traversal[8], step)
+	}
+}
+
+func TestSplatExpressionYAsTraversal(t *testing.T) {
+	expr, _ := ParseExpression([]byte("module.team[*].module.player[*].random_pet.ball[\"blue\"]"), "", hcl.Pos{})
+	traversal, diags := hcl.AbsTraversalForExpr(expr)
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics:\n%s", diags.Error())
+	}
+	if len(traversal) != 9 {
+		t.Fatalf("wrong traversal %#v; want length 9", traversal)
+	}
+	if traversal.RootName() != "module" {
+		t.Errorf("wrong root name %q; want %q", traversal.RootName(), "a")
+	}
+	if step, ok := traversal[1].(hcl.TraverseAttr); ok {
+		if got, want := step.Name, "team"; got != want {
+			t.Errorf("wrong name %q for step 1; want %q", got, want)
+		}
+	} else {
+		t.Errorf("wrong type %T for step 1; want %T", traversal[1], step)
+	}
+	if step, ok := traversal[2].(hcl.TraverseSplat); !ok {
+		t.Errorf("wrong type %T for step 2; want %T", traversal[2], step)
+	}
+	if step, ok := traversal[3].(hcl.TraverseAttr); ok {
+		if got, want := step.Name, "module"; got != want {
+			t.Errorf("wrong name %q for step 3; want %q", got, want)
+		}
+	} else {
+		t.Errorf("wrong type %T for step 3; want %T", traversal[3], step)
+	}
+	if step, ok := traversal[5].(hcl.TraverseSplat); !ok {
+		t.Errorf("wrong type %T for step 5; want %T", traversal[5], step)
+	}
+	if step, ok := traversal[8].(hcl.TraverseIndex); ok {
+		if got, want := step.Key, cty.StringVal("blue"); !want.RawEquals(got) {
+			t.Errorf("wrong name %#v for step 8; want %#v", got, want)
+		}
+	} else {
+		t.Errorf("wrong type %T for step 8; want %T", traversal[8], step)
+	}
+}
+
 func TestStaticExpressionList(t *testing.T) {
 	expr, _ := ParseExpression([]byte("[0, a, true]"), "", hcl.Pos{})
 	exprs, diags := hcl.ExprList(expr)


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

The wildcard expression, also called SplatExpr, should be a traverse-able entity. That way, we can use the `splat` symbol in addresses for OpenTofu.

## How Has This Been Tested?

I added a couple of parse tests against expressions using the splat symbol, expecting a `TraverseSplat`. 

